### PR TITLE
Catch fail snap

### DIFF
--- a/frontend/test/test_http_dealers.js
+++ b/frontend/test/test_http_dealers.js
@@ -30,8 +30,7 @@ describe('HTTPTests for Dealerships', function() {
         var dealers = JSON.parse(res.body);
         dbConnect.then(function(conn) {
           r.table('Dealership').count().run(conn, function(err, results){
-             // Purposely break this test, it will not === 5
-            assert.strictEqual(5, results, "same results from DB and HTTP response");
+            assert.strictEqual(dealers.length, results, "same results from DB and HTTP response");
             conn.close();
             done();
           });

--- a/frontend/test/test_http_vehicles.js
+++ b/frontend/test/test_http_vehicles.js
@@ -30,8 +30,7 @@ describe('HTTPTests for Vehicles', function() {
         var vehicles = JSON.parse(res.body);
         dbConnect.then(function(conn) {
           r.table('Vehicle').count().run(conn, function(err, results){
-            // Purposely break this test, it will not === 5
-            assert.strictEqual(5, results, "same results from DB and HTTP response")
+            assert.strictEqual(vehicles.length, results, "same results from DB and HTTP response")
             done();
           }); 
         }).error(function(error) {


### PR DESCRIPTION
fixed #41 

All tests no matter if failed or pass will run, at the end of all tests running this will check if 1 or more tests have failed, if so the build will fail but there will be snapshots for each failed build DB state. This is better than stopping the build at the first failed test, we will want all tests to run.

I purposely made a test fail with this and captured the output of how the changes react.

```
HTTPTests for Vehicles
    Testing /vehicles endpoint
      ✓ /vehicles should return "200" (1423ms)
      1) /vehicles should return the right amount of vehicles in the db


  1 passing (3s)
  1 failing

  1) HTTPTests for Vehicles Testing /vehicles endpoint /vehicles should return the right amount of vehicles in the db:

      Uncaught AssertionError: same results from DB and HTTP response
      + expected - actual

      -5
      +29390

      at test/test_http_vehicles.js:34:20
      at tryCatcher (node_modules/bluebird/js/main/util.js:26:23)
      at Promise.successAdapter (node_modules/bluebird/js/main/nodeify.js:23:30)
      at Promise._settlePromiseAt (node_modules/bluebird/js/main/promise.js:582:21)
      at Promise._settlePromises (node_modules/bluebird/js/main/promise.js:700:14)
      at Async._drainQueue (node_modules/bluebird/js/main/async.js:123:16)
      at Async._drainQueues (node_modules/bluebird/js/main/async.js:133:10)
      at Immediate.Async.drainQueues (node_modules/bluebird/js/main/async.js:15:14)



[FAILED TEST test_http_vehicles]: Taking snapshot of database and pushing it
Took snapshot: 17cbfe14-fb69-45c6-ac86-aa53a08c0103 of volume: c13a58b3-83e1-4025-bb04-b5d456c4168e
.
.
.
[more test may pass or fail]
.
.
.
Checking for failures...
Found failed tests: test_http_dealers test_http_vehicles
```

Snaphots also get metadata about that it is from a failed test see `Failed`

```
catch-fail-snap-test-Failed-test_http_vehicles-build-2      17cbfe14-fb69-45c6-ac86-aa53a08c0103 Snap for build 2, build id 2 build URL http://ec2-54-173-56-41.compute-1.amazonaws.com:8080/job/inventory-pipeline-multi/job/catch-fail-snap/2/ for test Failed-test_http_vehicles built on AWS-CentOS_7_zfs_dpcli (i-617cec50)
```
