### PR TITLE
Add hostname ip staging

### DIFF
--- a/ci-utils/runstaging.sh
+++ b/ci-utils/runstaging.sh
@@ -47,7 +47,7 @@ teardown() {
 
 publish_staging_env() {
    host=$(curl http://169.254.169.254/latest/meta-data/public-hostname)
-   port=$(cut -d ":" -f 2 <<< $(sudo docker port ${GITBRANCH}inventoryapp_frontend_1))
+   port=$(cut -d ":" -f 2 <<< $(sudo docker port ${GITBRANCH//-}inventoryapp_frontend_1))
    echo "Your staging environment is available at ${host}:${port}"
 }
 


### PR DESCRIPTION
outputs exact URL you can access it on.

```
Successfully built efbd03f0e0e8
Creating addhostnameipstaginginventoryapp_db_1
Creating addhostnameipstaginginventoryapp_frontend_1
CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS                  PORTS                                                                         NAMES
b6539b2a4b79        frontend            "npm start"              1 seconds ago       Up Less than a second   0.0.0.0:32811->8000/tcp                                                       addhostnameipstaginginventoryapp_frontend_1
7ae66be0fcfc        rethinkdb           "rethinkdb --bind all"   1 seconds ago       Up 1 seconds            0.0.0.0:32810->8080/tcp, 0.0.0.0:32809->28015/tcp, 0.0.0.0:32808->29015/tcp   addhostnameipstaginginventoryapp_db_1
.
.
.
Your staging environment is available at ec2-54-209-127-158.compute-1.amazonaws.com:32811
.
.
.
[Pipeline] }
[Pipeline] // node
[Pipeline] End of Pipeline
```
