### PR TITLE
a fli-docker manifest file to be used at a later time

### DIFF
--- a/fli-docker-manifest.yml
+++ b/fli-docker-manifest.yml
@@ -1,0 +1,10 @@
+docker_app: docker-compose.yml
+
+flocker_hub:
+    endpoint: http://<insert-url>
+    tokenfile: /path/to/token.txt
+
+volumes:
+    - name: rethink-data
+      snapshot: 750kvehicles
+      volumeset: inventory-app


### PR DESCRIPTION
Fixes https://github.com/ClusterHQ/inventory-app/issues/61
